### PR TITLE
Workflow to test install scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build
+name: "MetaCall Distributable Linux Release"
 
 on:
   push:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,23 @@
+name: Test Linux Install Script with new release
+
+on:
+  workflow_run:
+    workflows: ["MetaCall Distributable Linux Release"]
+    types:
+      - completed
+  
+jobs:
+    test:
+      runs-on: ubuntu-latest
+      if: ${{ github.event.workflow_run.conclusion == 'success' }}
+      steps:
+        - uses: convictional/trigger-workflow-and-wait@v1.6.1
+          with:
+            owner: metacall
+            repo: install
+            github_token: ${{ secrets.G_PERSONAL_ACCESS_TOKEN }}
+            workflow_file_name: test-linux.yml
+            wait_workflow: true
+            ref: master
+  
+


### PR DESCRIPTION
Triggers the test-linux.yml file in metacall/install

The failure of this workflow doesnt interfere with the release

Before merge add the following secret to this repo

`G_PERSONAL_ACCESS_TOKEN` :  Token got from Developer settings in owners settings