### PR TITLE
Use latest actions in GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build the base image
         run: docker build -t metacall/distributable_linux -f Dockerfile .
       - name: Install the additional channels and pull
@@ -36,7 +36,7 @@ jobs:
       - name: Build tarball
         run: docker run --rm -v $PWD/out:/metacall/pack --privileged metacall/distributable_linux /metacall/scripts/build.sh
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: built-tarball
           path: out/
@@ -48,8 +48,8 @@ jobs:
     needs: prep
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
-      - uses: actions/download-artifact@v3
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: built-tarball
           path: out/
@@ -74,10 +74,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # To fetch all tags
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: built-tarball
           path: out/


### PR DESCRIPTION
Most of our repositories currently use actions/upload-artifact@v3 for artifact uploading and actions/download-artifact@v3 for artifact downloading within our CI pipelines. However, an updated version, actions/upload-artifact@v4 and actions/download-artifact@v4, is now available and should be considered for adoption across our projects. @viferga 